### PR TITLE
feat: support custom key serializer

### DIFF
--- a/src/flatten.test.ts
+++ b/src/flatten.test.ts
@@ -203,6 +203,34 @@ describe('flattenObject', () => {
     testFlatten({ cat }, { cat });
   });
 
+  it('should be able to custom key serializer', () => {
+    expect(
+      flatten(
+        { a: [0, { b: [1], c: { d: [2], 5: [6] } }] },
+        {
+          serializeFlattenKey(key, prefix, meta) {
+            if (meta.isArrayIndex) {
+              return `${prefix}.[${key}]`;
+            }
+            if (
+              meta.hasSpecialCharacters ||
+              meta.isEmpty ||
+              /^\d+$/.test(key)
+            ) {
+              return `${prefix}[${JSON.stringify(key)}]`;
+            }
+            return prefix ? `${prefix}.${key}` : key;
+          },
+        },
+      ),
+    ).toEqual({
+      'a.[0]': 0,
+      'a.[1].b.[0]': 1,
+      'a.[1].c.d.[0]': 2,
+      'a.[1].c["5"].[0]': 6,
+    });
+  });
+
   it('should not throw on illegal input', () => {
     expect(flatten('' as any)).toEqual({});
   });

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -7,7 +7,24 @@ export const SPECIAL_CHARACTER_REGEX =
 export const config = {
   strict: false,
   circularReference: 'string' as const,
-};
+  serializeFlattenKey: (
+    key: string,
+    prefix: string,
+    meta: {
+      isArrayIndex: boolean;
+      isEmpty: boolean;
+      hasSpecialCharacters: boolean;
+    },
+  ) => {
+    if (meta.isArrayIndex) {
+      return `${prefix}[${key}]`;
+    }
+    if (meta.hasSpecialCharacters || meta.isEmpty || /^\d+$/.test(key)) {
+      return `${prefix}[${JSON.stringify(key)}]`;
+    }
+    return prefix ? `${prefix}.${key}` : key;
+  },
+} satisfies UniFlattenOptions;
 
 export const mergeConfig = (options?: UniFlattenOptions) => ({
   ...config,

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,14 @@
 export interface UniFlattenOptions {
   circularReference?: 'string' | 'symbol' | 'null';
   strict?: boolean;
+  serializeFlattenKey?: (
+    /** current key to serialize */
+    key: string,
+    prefix: string,
+    meta: {
+      isArrayIndex: boolean;
+      isEmpty: boolean;
+      hasSpecialCharacters: boolean;
+    },
+  ) => string;
 }


### PR DESCRIPTION
Closes #95

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/Nikaple/uni-flatten/blob/main/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Related issue linked using `fixes #number`
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Users can't define how to serialize flattened keys.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #95

## What is the new behavior?

A new option `serializeFlattenKey` is added to support custom key serializer. Default serializer:

```ts
const serializeFlattenKey = (
  key: string,
  prefix: string,
  meta: {
    isArrayIndex: boolean;
    isEmpty: boolean;
    hasSpecialCharacters: boolean;
  },
) => {
  if (meta.isArrayIndex) {
    return `${prefix}[${key}]`;
  }
  if (meta.hasSpecialCharacters || meta.isEmpty || /^\d+$/.test(key)) {
    return `${prefix}[${JSON.stringify(key)}]`;
  }
  return prefix ? `${prefix}.${key}` : key;
}
```

Users can provide their custom key serializers in the second parameter of `flatten`, or configure globally with `configureUniFlatten`.

When this option is configured, library can no longer guarantee that the flattened object can be unflattened back. Not sure if it's a good idea, though.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
