### PR TITLE
add prototype pollution guard

### DIFF
--- a/src/deep-set.ts
+++ b/src/deep-set.ts
@@ -9,6 +9,8 @@ import {
 } from './internal';
 import { UniFlattenOptions } from './type';
 
+export const RESTRICTED_KEYS = ['__proto__', 'constructor', 'prototype'];
+
 /**
  * Deeply set value by key. This method mutates the original object.
  *
@@ -36,6 +38,10 @@ export const deepSet = <T extends Record<string, unknown>>(
   let currentKey = '';
 
   keys.forEach((key, i, arr) => {
+    if (typeof key === 'string' && RESTRICTED_KEYS.includes(key)) {
+      throw new Error(`Access to restricted key "${key}" blocked!`);
+    }
+
     const isNextArray = typeof arr[i + 1] === 'number';
     const keyString = String(key);
     const hasSpecialCharacters = SPECIAL_CHARACTER_REGEX.test(keyString);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/Nikaple/uni-flatten/blob/main/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Related issue linked using `fixes #number`
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`deepSet()` currently allows unsafe keys like `__proto__`, which can lead to prototype pollution in `unflatten()`

Issue Number: N/A

## What is the new behavior?

add denylist for unsafe keys

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
